### PR TITLE
Specify recommended workspace resolver for rust 2024

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,3 +3,5 @@ members = [
     "threshold",
     "cli", "tgrpc",
 ]
+
+resolver = "3"


### PR DESCRIPTION
When building the workspace i get the warning:

```
warning: virtual workspace defaulting to `resolver = "1"` despite one or more workspace members being on edition 2024 which implies `resolver = "3"`
note: to keep the current resolver, specify `workspace.resolver = "1"` in the workspace root's manifest
note: to use the edition 2024 resolver, specify `workspace.resolver = "3"` in the workspace root's manifest
note: for more details see https://doc.rust-lang.org/cargo/reference/resolver.html#resolver-versions
```

This PR sets the the resolver to "3" which uses per-dependency feature propagation and is generally recommended for new projects.  